### PR TITLE
Add launch parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,48 @@ Boomhauer is a library to simplify writing [AWS Lambda](https://aws.amazon.com/l
 [![Dependencies Status](https://jarkeeper.com/TheClimateCorporation/boomhauer/status.svg)](https://jarkeeper.com/TheClimateCorporation/boomhauer)
 [![Build Status](https://travis-ci.org/TheClimateCorporation/boomhauer.svg?branch=master)](https://travis-ci.org/TheClimateCorporation/boomhauer)
 
+## Usage
+
+Boomhauer makes registering `intents` and their handlers pretty easy.
+Create a request handler that looks similar to the below code example:
+
+```clojure
+(ns your.speechlet-request-handler
+  (:gen-class
+    :name your.SpeechletRequestHandler
+    :extends com.amazon.speech.speechlet.lambda.SpeechletRequestStreamHandler
+    :init init
+    :constructors {[] [com.amazon.speech.speechlet.Speechlet java.util.Set]})
+
+  (:use [your.custom-intent])
+
+  (:import [com.climate.boomhauer BoomhauerSpeechlet]))
+
+(defn -init []
+  [[(BoomhauerSpeechlet.
+      {:launch-message "Intro message when skill launches"
+       :card-title "Your Skill"}), #{}] nil])
+```
+
+Then, create an intent for your skill (that looks something like the
+code below):
+
+```clojure
+(ns your.intent
+  (:require [com.climate.boomhauer.intent-handler :refer [defintent]])
+  (:import [com.amazon.speech.speechlet SpeechletResponse]
+           [com.amazon.speech.ui PlainTextOutputSpeech]))
+
+(defn- mk-plain-speech [text]
+  (doto (PlainTextOutputSpeech.) (.setText text)))
+
+(defn hello-world [session session-map]
+  (let [speech (mk-plain-speech "Hello, world!")]
+    (SpeechletResponse/newTellResponse speech)))
+
+(defintent :HelloWorldIntent hello-world)
+```
+
 ## Acknowledgments
 
 Shoutouts to [Mario Aquino](https://github.com/marioaquino), [Jeff Melching](https://github.com/jmelching),

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.climate/boomhauer "0.1.0"
+(defproject com.climate/boomhauer "0.1.1"
   :description "Library for writing AWS Lambda functions in Clojure to handle Alexa voice requests"
   :url "https://github.com/TheClimateCorporation/boomhauer"
   :min-lein-version "2.0.0"
@@ -14,8 +14,8 @@
   :dependencies [[org.clojure/data.json "0.2.6"]
                  [com.amazonaws/aws-lambda-java-core "1.1.0"]
                  [com.amazonaws/aws-lambda-java-events "1.1.0"]
-                 [com.amazon.alexa/alexa-skills-kit "1.1.1"]
-                 [org.clojure/clojure "1.7.0"]
+                 [com.amazon.alexa/alexa-skills-kit "1.1.3"]
+                 [org.clojure/clojure "1.8.0"]
                  [clj-http "2.0.0"]
                  [cheshire "5.5.0"]
                  [clj-time "0.11.0"]

--- a/src/main/clojure/com/climate/boomhauer/launch_handler.clj
+++ b/src/main/clojure/com/climate/boomhauer/launch_handler.clj
@@ -3,9 +3,8 @@
            (com.amazon.speech.ui SimpleCard PlainTextOutputSpeech Reprompt)))
 
 (defn handle
-  [^LaunchRequest request ^Session session]
-  (let [speech-text "??????"
-        card (doto (SimpleCard.) (.setTitle "????") (.setContent speech-text))
-        speech (doto (PlainTextOutputSpeech.) (.setText speech-text))
+  [^LaunchRequest request ^Session session launch-message card-title]
+  (let [card (doto (SimpleCard.) (.setTitle card-title) (.setContent launch-message))
+        speech (doto (PlainTextOutputSpeech.) (.setText launch-message))
         reprompt (doto (Reprompt.) (.setOutputSpeech speech))]
     (SpeechletResponse/newAskResponse speech reprompt card)))

--- a/src/main/clojure/com/climate/boomhauer/speechlet.clj
+++ b/src/main/clojure/com/climate/boomhauer/speechlet.clj
@@ -1,7 +1,11 @@
 (ns com.climate.boomhauer.speechlet
   (:gen-class
     :name com.climate.boomhauer.BoomhauerSpeechlet
-    :implements [com.amazon.speech.speechlet.Speechlet])
+    :implements [com.amazon.speech.speechlet.Speechlet]
+    :state launchParams
+    :init init
+    :constructors {[] []
+                   [java.util.Map] []})
   (:import [com.amazon.speech.speechlet Session
                                         SessionEndedRequest
                                         IntentRequest
@@ -11,6 +15,15 @@
             [com.climate.boomhauer.launch-handler :as launch]
             [com.climate.boomhauer.intent-handler :as intent]))
 
+(defn- mk-default-constructor-params []
+  {:launch-message "No launch message provided" :card-title ""})
+
+(defn -init
+  ([]
+   [[] (mk-default-constructor-params)])
+  ([^java.util.Map launch-params]
+   [[] (merge (mk-default-constructor-params) launch-params)]))
+
 ; void onSessionStarted(SessionStartedRequest request, Session session) throws SpeechletException;
 (defn -onSessionStarted
   [_ ^SessionStartedRequest request ^Session session]
@@ -19,9 +32,10 @@
 
 ; SpeechletResponse onLaunch(LaunchRequest request, Session session) throws SpeechletException;
 (defn -onLaunch
-  [_ ^LaunchRequest request ^Session session]
+  [this ^LaunchRequest request ^Session session]
   (log/infof "launch, request [%s], session [%s]" (.getRequestId request) (.getSessionId session))
-  (launch/handle request session))
+  (let [{:keys [launch-message card-title]} (.launchParams this)]
+    (launch/handle request session launch-message card-title)))
 
 ; SpeechletResponse onIntent(IntentRequest request, Session session) throws SpeechletException;
 (defn -onIntent

--- a/src/test/clojure/com/climate/boomhauer/speechlet_test.clj
+++ b/src/test/clojure/com/climate/boomhauer/speechlet_test.clj
@@ -7,31 +7,54 @@
   (:import [com.amazon.speech.speechlet SpeechletResponse]))
 
 (deftest speechlet
-  (testing "onSessionStarted"
-    (let [session-started-request (helper/build-session-started-request "request id")
-          session (helper/build-session)]
-      (is (nil? (speechlet/-onSessionStarted nil session-started-request session)))))
-  (testing "onSessionEnded"
-    (let [session-ended-request (helper/build-session-ended-request "request id")
-          session (helper/build-session)]
-      (is (nil? (speechlet/-onSessionEnded nil session-ended-request session)))))
-  (testing "onLaunch"
-    (let [launch-request (helper/build-launch-request)
-          session (helper/build-session)
-          stub-response (SpeechletResponse.)
-          stub-handle (fn [input-launch-request input-session]
-                        (is (= launch-request input-launch-request))
-                        (is (= session input-session))
-                        stub-response)]
-      (with-redefs [launch-handler/handle stub-handle]
-        (is (= stub-response (speechlet/-onLaunch nil launch-request session))))))
-  (testing "onIntent"
-    (let [intent-request (helper/build-intent-request "intent")
-          session (helper/build-session)
-          stub-response (SpeechletResponse.)
-          stub-handle (fn [input-intent-request input-session]
-                        (is (= intent-request input-intent-request))
-                        (is (= session input-session))
-                        stub-response)]
-      (with-redefs [intent-handler/handle stub-handle]
-        (is (= stub-response (speechlet/-onIntent nil intent-request session)))))))
+  (let [speechlet-under-test (com.climate.boomhauer.BoomhauerSpeechlet.)]
+
+    (testing "onSessionStarted"
+      (let [session-started-request (helper/build-session-started-request "request id")
+            session (helper/build-session)]
+        (is (nil? (.onSessionStarted speechlet-under-test session-started-request session)))))
+    (testing "onSessionEnded"
+      (let [session-ended-request (helper/build-session-ended-request "request id")
+            session (helper/build-session)]
+        (is (nil? (.onSessionEnded speechlet-under-test session-ended-request session)))))
+    (testing "onLaunch with no constructor params"
+      (let [launch-request (helper/build-launch-request)
+            session (helper/build-session)
+            stub-response (SpeechletResponse.)
+            default-launch-message "No launch message provided"
+            default-card-title ""
+            stub-handle (fn [input-launch-request input-session launch-message card-title]
+                          (is (= launch-request input-launch-request))
+                          (is (= session input-session))
+                          (is (= default-launch-message launch-message))
+                          (is (= default-card-title card-title))
+                          stub-response)]
+        (with-redefs [launch-handler/handle stub-handle]
+          (is (= stub-response (.onLaunch speechlet-under-test launch-request session))))))
+    (testing "onLaunch with constructor params"
+      (let [launch-request (helper/build-launch-request)
+            session (helper/build-session)
+            stub-response (SpeechletResponse.)
+            expected-launch-message "dang ol' Jeronimoe!!!"
+            expected-card-title "Boom"
+            stub-handle (fn [input-launch-request input-session launch-message card-title]
+                          (is (= launch-request input-launch-request))
+                          (is (= session input-session))
+                          (is (= expected-launch-message launch-message))
+                          (is (= expected-card-title card-title))
+                          stub-response)
+            speechlet-under-test (com.climate.boomhauer.BoomhauerSpeechlet.
+                                     {:launch-message expected-launch-message
+                                      :card-title expected-card-title})]
+        (with-redefs [launch-handler/handle stub-handle]
+          (is (= stub-response (.onLaunch speechlet-under-test launch-request session))))))
+    (testing "onIntent"
+      (let [intent-request (helper/build-intent-request "intent")
+            session (helper/build-session)
+            stub-response (SpeechletResponse.)
+            stub-handle (fn [input-intent-request input-session]
+                          (is (= intent-request input-intent-request))
+                          (is (= session input-session))
+                          stub-response)]
+        (with-redefs [intent-handler/handle stub-handle]
+          (is (= stub-response (.onIntent speechlet-under-test intent-request session))))))))


### PR DESCRIPTION
This PR adds support for passing a launch message and card title as parameters when your skill is launched.  It also adds an example to the README showing how to use the launch parameters.
